### PR TITLE
docs: remove deprecated 'n_lines_to_search' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ If you don't provide any arguments to the setup function, default values will be
 
 ```lua
 {
-    n_lines_to_search = 100 -- how many lines should be searched for a matching delimiter
     highlight_in_insert_mode = true, -- should highlighting also be done in insert mode
     delay = 100, -- delay before the highglight
 }

--- a/doc/hl_match_area.txt
+++ b/doc/hl_match_area.txt
@@ -43,7 +43,6 @@ hl_match_area.setup({user_config})                         *hl_match_area.setup*
     Config has a following structure and purpose
     >
     {
-      n_lines_to_search: number -- how many lines should be searched for a matching delimiter
       highlight_in_insert_mode: boolean, -- should highlighting also be done in insert mode
       delay: 100, -- delay in miliseconds to highlight
     }
@@ -52,7 +51,6 @@ hl_match_area.setup({user_config})                         *hl_match_area.setup*
     Any of the values can be empty if so default config values are used.
     Default config values are as follows
     >
-      n_lines_to_search = 100,
       highlight_in_insert_mode = true,
       delay = 100,
     <


### PR DESCRIPTION
The `n_lines_to_search` configuration option was
removed in #5 because `searchpairpos()` doesn't
need it. This commit removes that deprecated
option from the documentation.